### PR TITLE
Fix/flow issue issues arw fixed

### DIFF
--- a/src/app/customer/projects/page.tsx
+++ b/src/app/customer/projects/page.tsx
@@ -11,6 +11,7 @@ import {
   CalendarCheck,
   AlertTriangle,
   MessageSquare,
+  CheckCircle2,
 } from 'lucide-react';
 import ProjectHeader from '@/components/customer/ProjectHeader';
 import ProjectInfoTile from '@/components/customer/ProjectInfoTile';
@@ -487,11 +488,28 @@ export default function ProjectsPage() {
                 <div className="flex items-center gap-2">
                   <Car className="h-4 w-4 text-gray-500" />
                   <div>
-                    <p className="text-xs text-gray-500">Vehicle ID</p>
-                    <p className="text-sm font-medium">#{proj.vehicleId || 'N/A'}</p>
+                    <p className="text-xs text-gray-500">Vehicle</p>
+                    <p className="text-sm font-medium">{proj.vehicleName || `#${proj.vehicleId}` || 'N/A'}</p>
                   </div>
                 </div>
               </div>
+
+              {/* Completion Message - Only show for completed projects */}
+              {proj.status === 'COMPLETED' && proj.completionMessage && (
+                <div className="mb-4 p-4 bg-green-50 border-l-4 border-green-500 rounded-lg">
+                  <div className="flex items-start gap-2">
+                    <CheckCircle2 className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                    <div className="flex-1">
+                      <p className="text-sm font-semibold text-green-900 mb-1">
+                        Project Completion Message
+                      </p>
+                      <p className="text-sm text-green-800">
+                        {proj.completionMessage}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               <div className="flex gap-3 mt-4">
                 <a

--- a/src/app/customer/reports/page.tsx
+++ b/src/app/customer/reports/page.tsx
@@ -44,11 +44,16 @@ export default function CustomerReportsPage() {
     try {
       setLoading(true);
       const appointments = await appointmentService.getAllAppointmentsForCurrentCustomer();
+      
+      // Get all projects to check which appointments have projects
+      const allProjects = await projectService.getAllProjectsForCurrentCustomer();
 
-      // Filter only COMPLETED appointments
-      const completed = appointments.filter(
-        apt => apt.status?.toUpperCase() === 'COMPLETED'
-      );
+      // Filter only COMPLETED appointments that don't have projects created yet
+      const completed = appointments.filter(apt => {
+        const isCompleted = apt.status?.toUpperCase() === 'COMPLETED';
+        const hasProject = allProjects.some(proj => proj.appointmentId === apt.id);
+        return isCompleted && !hasProject;
+      });
 
       setCompletedAppointments(completed);
     } catch (err) {
@@ -471,6 +476,17 @@ export default function CustomerReportsPage() {
                 {/* Service Report Details */}
                 {isExpanded && appointment.tasks && appointment.tasks.length > 0 && (
                   <div className="p-6">
+                    {/* Employee Notes/Report */}
+                    {appointment.notes && (
+                      <div className="mb-6 p-4 bg-blue-50 rounded-lg border border-blue-200">
+                        <h4 className="font-semibold text-blue-900 mb-2 flex items-center gap-2">
+                          <FileText className="h-5 w-5" />
+                          Technician's Report
+                        </h4>
+                        <p className="text-gray-800 text-sm whitespace-pre-wrap">{appointment.notes}</p>
+                      </div>
+                    )}
+
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">
                       Services Performed
                     </h3>

--- a/src/components/customer/AppointmentList.tsx
+++ b/src/components/customer/AppointmentList.tsx
@@ -30,7 +30,10 @@ import {
   AlertCircle,
   HelpCircle,
   Eye,
+  FileText,
+  CheckCircle,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
   AppointmentData,
@@ -81,9 +84,15 @@ export default function AppointmentList({
   onDelete,
   isLoading = false,
 }: AppointmentListProps) {
+  const router = useRouter();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewingAppointment, setViewingAppointment] =
     useState<AppointmentData | null>(null);
+
+  // Check if appointment has a report ready
+  const hasReportReady = (appointment: AppointmentData) => {
+    return appointment.status === "COMPLETED" && !!appointment.notes && appointment.notes.trim().length > 0;
+  };
 
   const handleDelete = async (appointmentId: string) => {
     try {
@@ -256,10 +265,33 @@ export default function AppointmentList({
                           {statusLabels[appointment.status]}
                         </Badge>
                       </div>
+                      {/* Report Ready Indicator */}
+                      {hasReportReady(appointment) && (
+                        <div className="flex items-center gap-1 mt-2">
+                          <CheckCircle className="h-4 w-4 text-green-600" />
+                          <span className="text-xs text-green-700 font-semibold">
+                            Report Ready
+                          </span>
+                        </div>
+                      )}
                     </TableCell>
 
                     <TableCell className="py-8 px-4 pr-6">
                       <div className="flex justify-start gap-2">
+                        {/* View Report Button for Completed Appointments with Notes */}
+                        {hasReportReady(appointment) && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => router.push('/customer/reports')}
+                            className="hover:bg-green-50 hover:border-green-300 transition-all duration-200 shadow-sm hover:shadow-md border-2 flex items-center gap-1"
+                            disabled={isLoading}
+                          >
+                            <FileText className="h-4 w-4 text-green-600" />
+                            <span className="text-xs font-medium">View Report</span>
+                          </Button>
+                        )}
+                        
                         {/* View Button */}
                         <Button
                           variant="outline"
@@ -370,15 +402,26 @@ export default function AppointmentList({
               >
                 <CardContent className="p-6">
                   <div className="flex justify-between items-start mb-4">
-                    <Badge
-                      className={cn(
-                        "border-2 px-3 py-1 text-sm font-semibold rounded-full shadow-sm",
-                        statusColors[appointment.status]
+                    <div className="flex flex-col gap-2">
+                      <Badge
+                        className={cn(
+                          "border-2 px-3 py-1 text-sm font-semibold rounded-full shadow-sm w-fit",
+                          statusColors[appointment.status]
+                        )}
+                        variant="outline"
+                      >
+                        {statusLabels[appointment.status]}
+                      </Badge>
+                      {/* Report Ready Indicator */}
+                      {hasReportReady(appointment) && (
+                        <div className="flex items-center gap-1">
+                          <CheckCircle className="h-4 w-4 text-green-600" />
+                          <span className="text-xs text-green-700 font-semibold">
+                            Report Ready
+                          </span>
+                        </div>
                       )}
-                      variant="outline"
-                    >
-                      {statusLabels[appointment.status]}
-                    </Badge>
+                    </div>
 
                     <div className="flex gap-2">
                       {canEdit(appointment.status) && (
@@ -543,6 +586,19 @@ export default function AppointmentList({
                             </p>
                           </div>
                         </div>
+                      </div>
+                    )}
+
+                    {/* View Report Button for Mobile */}
+                    {hasReportReady(appointment) && (
+                      <div className="mt-4">
+                        <Button
+                          onClick={() => router.push('/customer/reports')}
+                          className="w-full bg-green-600 hover:bg-green-700 text-white font-semibold"
+                        >
+                          <FileText className="h-4 w-4 mr-2" />
+                          View Technician Report
+                        </Button>
                       </div>
                     )}
                   </div>

--- a/src/lib/services/projectService.ts
+++ b/src/lib/services/projectService.ts
@@ -29,6 +29,9 @@ export interface Project {
   mainRepresentativeEmployeeId?: number;
   mainRepresentativeEmployeeName?: string;
   isMainRepresentative?: boolean;
+  taskIds?: number[]; // List of task IDs associated with this project
+  assignedEmployeeIds?: number[]; // List of assigned employee IDs
+  completionMessage?: string; // Completion message from employee
 }
 
 export interface TaskCompletion {

--- a/src/lib/types/Appointment.ts
+++ b/src/lib/types/Appointment.ts
@@ -13,7 +13,7 @@ export type AppointmentStatus =
   | 'CONFIRMED'
   | 'IN_PROGRESS'
   | 'COMPLETED'
-  | 'CANCELLED';
+  | 'CANCELED';
 
 // Consultation types - what customer is seeking help for
 export type ConsultationType =


### PR DESCRIPTION
This pull request adds new functionality to display technician reports and project completion messages for customers, improves the visibility of completed appointments and reports, and updates some data model types. The main changes are grouped below by theme.

**Customer-facing UI improvements:**

* Added a "Project Completion Message" section to completed projects in `src/app/customer/projects/page.tsx`, showing a green-highlighted message if available.
* Added a "Report Ready" indicator and a "View Report" button for completed appointments with technician notes in both desktop and mobile views in `src/components/customer/AppointmentList.tsx`. [[1]](diffhunk://#diff-0bb88636ff0304bf0370534e0a8cf0c2a9911cbe3cc90fe1bc4977245ba3f377R268-R294) [[2]](diffhunk://#diff-0bb88636ff0304bf0370534e0a8cf0c2a9911cbe3cc90fe1bc4977245ba3f377R405-R424) [[3]](diffhunk://#diff-0bb88636ff0304bf0370534e0a8cf0c2a9911cbe3cc90fe1bc4977245ba3f377R591-R603)
* Displayed technician notes ("Technician's Report") for completed appointments in the reports page, styled with a blue highlight in `src/app/customer/reports/page.tsx`.

**Logic and filtering updates:**

* Updated the reports page to only show completed appointments that do not yet have an associated project, by cross-checking appointments and projects.
* Added a helper function to check if an appointment has a report ready (completed status and non-empty notes) in `src/components/customer/AppointmentList.tsx`.

**Data model changes:**

* Extended the `Project` interface to include `assignedEmployeeIds` and `completionMessage` fields in `src/lib/services/projectService.ts`.
* Updated the spelling of the appointment status value from `'CANCELLED'` to `'CANCELED'` in `src/lib/types/Appointment.ts`.

**Icon imports:**

* Added new icon imports (`CheckCircle2`, `FileText`, `CheckCircle`) to support the new UI indicators and buttons. [[1]](diffhunk://#diff-80b8d24bbe2877d7f0631e36c18692ad2284a8c1d26d9c8cafc0009561590cb8R14) [[2]](diffhunk://#diff-0bb88636ff0304bf0370534e0a8cf0c2a9911cbe3cc90fe1bc4977245ba3f377R33-R36)